### PR TITLE
Fix plugin's package.json

### DIFF
--- a/source/package.json
+++ b/source/package.json
@@ -6,19 +6,14 @@
 	},
 	"name": "nativescript-imagepicker",
 	"version": "0.0.4",
-    "nativescript": {
-        "id": "org.nativescript.imagepicker",
-        "platforms": {
-            "tns-android": {
-                "version": "1.4.0"
-            },
-            "tns-ios": {
-                "version": "1.4.0"
-            }
-        }
-    },
+	"nativescript": {
+	    "platforms": {
+	        "android": "1.4.0",
+	        "ios": "1.4.0"
+	    }
+	},
     "dependencies": {
-		"tns-core-modules": "1.4.0"
+		"tns-core-modules": "^1.4.0"
 	},
     "main": "viewmodel.js"
 }


### PR DESCRIPTION
Fix plugin's package.json to have:
* correct nativescript key - current nateivescript key had been copy-pasted from project. Plugin's nativescript key has different structure.
* set required version of `tns-core-modules` to use `^`, so new versions will be used when they are released.