### PR TITLE
Fix slow & crashing images (Master Branch)

### DIFF
--- a/nativescript-imagepicker/images.ios.ts
+++ b/nativescript-imagepicker/images.ios.ts
@@ -8,6 +8,11 @@ export function pageLoaded(args) {
     page = args.object;
     page.bindingContext = page.navigationContext;
     list = page.getViewById("images-list");
+
+    // Get the current Size, and then adjust the number of columns based on it...
+    var size = iOSProperty(UIScreen, UIScreen.mainScreen).bounds.size.width;
+    list.listViewLayout.spanCount = Math.floor(size / 80);
+
 }
 
 export function done(args) {
@@ -16,4 +21,13 @@ export function done(args) {
     topmost.goBack();
 
     page.bindingContext.imagePicker.done();
+}
+
+function iOSProperty(_this, property) {
+    if (typeof property === "function") {
+        return property.call(_this);
+    }
+    else {
+        return property;
+    }
 }

--- a/nativescript-imagepicker/images.xml
+++ b/nativescript-imagepicker/images.xml
@@ -1,30 +1,30 @@
-<Page xmlns="http://www.nativescript.org/tns.xsd" loaded="pageLoaded">
+<Page xmlns="http://www.nativescript.org/tns.xsd" loaded="pageLoaded"
+      xmlns:lv="nativescript-telerik-ui/listview">
 
-	<Page.actionBar>
-		<ActionBar title="{{ title }}">
-			<ActionBar.navigationButton>
-				<NavigationButton text="Albums" />
-			</ActionBar.navigationButton>
-			<ActionBar.actionItems>
-				<!-- enabled="{{ selection.length > 0 }}" -->
-				<ActionItem  text="{{ imagePicker.selection.length, imagePicker.doneText + (imagePicker.mode === 'single' ? '' : ' (' + imagePicker.selection.length + ')') }}" ios.position="right" tap="done" />
-			</ActionBar.actionItems>
-		</ActionBar>
-	</Page.actionBar>
+    <Page.actionBar>
+        <ActionBar title="{{ title }}">
+            <ActionBar.navigationButton>
+                <NavigationButton text="Albums"/>
+            </ActionBar.navigationButton>
+            <ActionBar.actionItems>
+                <ActionItem
+                        text="{{ imagePicker.selection.length, imagePicker.doneText + (imagePicker.mode === 'single' ? '' : ' (' + imagePicker.selection.length + ')') }}"
+                        ios.position="right" tap="done"/>
+            </ActionBar.actionItems>
+        </ActionBar>
+    </Page.actionBar>
 
-	<ScrollView>
-		<Repeater id="images-list" items="{{ assets }}">
-			<Repeater.itemsLayout>
-				<WrapLayout />
-			</Repeater.itemsLayout>
-			<Repeater.itemTemplate>
-				<GridLayout width="94" height="94" tap="{{ toggleSelection }}">
-					<Image opacity="{{ selected ? 0.7 : 1 }}" imageSource="{{ thumb }}" />
-					<Border opacity="{{ selected ? 1 : 0 }}" width="24" height="24" margin="2" horizontalAlignment="right" verticalAlignment="bottom" borderWidth="1" borderColor="white" backgroundColor="blue" borderRadius="12">
-					</Border>
-				</GridLayout>
-			</Repeater.itemTemplate>
-		</Repeater>
-	</ScrollView>
-
+    <lv:RadListView id="images-list" items="{{ assets }}" >
+        <lv:RadListView.listViewLayout>
+            <lv:ListViewGridLayout scrollDirection="Vertical" spanCount="3" itemHeight="100"/>
+        </lv:RadListView.listViewLayout>
+        <lv:RadListView.itemTemplate>
+            <GridLayout margin="2" rows="auto" tap="{{ toggleSelection }}">
+                <Image height="98" stretch="fill" opacity="{{ selected ? 0.7 : 1 }}" imageSource="{{ thumb }}"/>
+                <Border opacity="{{ selected ? 1 : 0 }}" width="24" height="24" margin="2" horizontalAlignment="right"
+                        verticalAlignment="bottom" borderWidth="1" borderColor="white" backgroundColor="blue"
+                        borderRadius="12"/>
+            </GridLayout>
+        </lv:RadListView.itemTemplate>
+    </lv:RadListView>
 </Page>

--- a/nativescript-imagepicker/images.xml
+++ b/nativescript-imagepicker/images.xml
@@ -16,11 +16,11 @@
 
     <lv:RadListView id="images-list" items="{{ assets }}" >
         <lv:RadListView.listViewLayout>
-            <lv:ListViewGridLayout scrollDirection="Vertical" spanCount="3" itemHeight="100"/>
+            <lv:ListViewGridLayout scrollDirection="Vertical" spanCount="4" itemHeight="80"/>
         </lv:RadListView.listViewLayout>
         <lv:RadListView.itemTemplate>
-            <GridLayout margin="2" rows="auto" tap="{{ toggleSelection }}">
-                <Image height="98" stretch="fill" opacity="{{ selected ? 0.7 : 1 }}" imageSource="{{ thumb }}"/>
+            <GridLayout margin="1" rows="auto" tap="{{ toggleSelection }}">
+                <Image height="78" width="78" opacity="{{ selected ? 0.7 : 1 }}" imageSource="{{ thumb }}"/>
                 <Border opacity="{{ selected ? 1 : 0 }}" width="24" height="24" margin="2" horizontalAlignment="right"
                         verticalAlignment="bottom" borderWidth="1" borderColor="white" backgroundColor="blue"
                         borderRadius="12"/>

--- a/nativescript-imagepicker/package.json
+++ b/nativescript-imagepicker/package.json
@@ -13,7 +13,8 @@
     }
   },
   "dependencies": {
-    "tns-core-modules": "*"
+    "tns-core-modules": "*",
+	"nativescript-telerik-ui": "*"
   },
   "main": "viewmodel.js",
   "devDependencies": {


### PR DESCRIPTION
This fixes the issue #38 - it looks like pull #39 also fixes it the same way; however my layout looks like Apples (4 up on standard phone) & more optimized and has a lot less white space...   It also adjusts the number of columns on larger devices to eliminate as much white space as possible...

Mine: 
![pasted image at 2016_10_21 06_54 pm](https://cloud.githubusercontent.com/assets/850871/19617105/cb5e5a00-97ec-11e6-9ad0-3db9f7c4cde9.png)


#39's:
![pasted image at 2016_10_21 05_23 am](https://cloud.githubusercontent.com/assets/850871/19612789/3d994aa6-97ae-11e6-842c-44356248c3f3.png)
