### PR TITLE
Supporting webpack

### DIFF
--- a/examples/ExampleImgPick/package.json
+++ b/examples/ExampleImgPick/package.json
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "nativescript-imagepicker": "file:../../nativescript-imagepicker",
-    "tns-core-modules": "2.3.0"
+    "tns-core-modules": "2.5.0"
   },
   "devDependencies": {
     "babel-traverse": "6.15.0",

--- a/nativescript-imagepicker/package.json
+++ b/nativescript-imagepicker/package.json
@@ -13,13 +13,13 @@
     }
   },
   "dependencies": {
-    "tns-core-modules": "*",
+    "tns-core-modules": ">=2.5.0",
     "nativescript-telerik-ui": "*"
   },
   "main": "viewmodel",
   "devDependencies": {
     "tns-platform-declarations": "next",
-    "typescript": "^2.0.3"
+    "typescript": "~2.0.10"
   },
   "scripts": {
     "tsc": "tsc",

--- a/nativescript-imagepicker/package.json
+++ b/nativescript-imagepicker/package.json
@@ -16,7 +16,7 @@
     "tns-core-modules": "*",
     "nativescript-telerik-ui": "*"
   },
-  "main": "viewmodel.js",
+  "main": "viewmodel",
   "devDependencies": {
     "tns-platform-declarations": "next",
     "typescript": "^2.0.3"


### PR DESCRIPTION
In order to be a webpack-discoverable module, we need to remove the `.js` suffix in the package.json `main` attribute. This allows webpack to correctly look for `my-module.android.js` or `my-module.ios.js`.

Details here:
http://docs.nativescript.org/angular/tooling/bundling-with-webpack.html#referencing-platform-specific-modules-from-packagejson