### PR TITLE
Include nativescirpt telerik ui as a dependency.

### DIFF
--- a/examples/ExampleImgPick/package.json
+++ b/examples/ExampleImgPick/package.json
@@ -18,6 +18,7 @@
   },
   "dependencies": {
     "nativescript-imagepicker": "file:../../nativescript-imagepicker",
+    "nativescript-telerik-ui": "^2.0.1",
     "tns-core-modules": "^3.0.0 || ^3.0.0-rc.1"
   },
   "devDependencies": {

--- a/examples/ExampleImgPickNG/package.json
+++ b/examples/ExampleImgPickNG/package.json
@@ -23,6 +23,7 @@
     "@angular/router": "~4.1.0",
     "nativescript-angular": "rc",
     "nativescript-imagepicker": "file:../../nativescript-imagepicker",
+    "nativescript-telerik-ui": "^2.0.1",
     "nativescript-theme-core": "^1.0.3",
     "reflect-metadata": "~0.1.8",
     "rxjs": "^5.3.0",


### PR DESCRIPTION
Include `nativescirpt telerik ui` as a dependency. It will not be added while installing the plugin.