### PR TITLE
iOS: Parameters for button texts

### DIFF
--- a/nativescript-imagepicker/index.d.ts
+++ b/nativescript-imagepicker/index.d.ts
@@ -80,7 +80,20 @@ interface Options {
      */
     mode?: string;
 
+    /**
+    * Set the text for the done button in iOS
+    */
     doneText?: string;
+
+    /**
+    * Set the text for the cancel button in iOS
+    */
+    cancelText?: string;
+
+    /**
+    * Set the text for the albums button in iOS
+    */
+    albumsText?: string;
 
     android?: {
         /**

--- a/nativescript-imagepicker/index.d.ts
+++ b/nativescript-imagepicker/index.d.ts
@@ -80,6 +80,8 @@ interface Options {
      */
     mode?: string;
 
+    doneText?: string;
+
     android?: {
         /**
          * Provide a reason for permission request to access external storage on api levels above 23.

--- a/nativescript-imagepicker/viewmodel.ios.ts
+++ b/nativescript-imagepicker/viewmodel.ios.ts
@@ -74,11 +74,11 @@ export class ImagePicker extends data_observable.Observable {
     }
 
     get cancelText(): string {
-        return "Cancel";
+        return this._options && this._options.cancelText ? this._options.cancelText : "Cancel";
     }
 
     get albumsText(): string {
-        return "Albums";
+        return this._options && this._options.albumsText ? this._options.albumsText :  "Albums";
     }
 
     get mode(): string {

--- a/nativescript-imagepicker/viewmodel.ios.ts
+++ b/nativescript-imagepicker/viewmodel.ios.ts
@@ -70,7 +70,7 @@ export class ImagePicker extends data_observable.Observable {
     }
 
     get doneText(): string {
-        return "Done";
+        return this._options && this._options.doneText ? this._options.doneText : "Done";
     }
 
     get cancelText(): string {


### PR DESCRIPTION
For iOS you can now provide options for doneText, cancelText and albumsText to allow translation strings for the album buttons.