### PR TITLE
Play nice with nativescript-telerik-ui-pro

### DIFF
--- a/src/package.json
+++ b/src/package.json
@@ -28,7 +28,8 @@
         "plugin.tscwatch": "npm run tsc -- -w",
         "demo.ios": "npm i && npm run tsc && cd ../demo && tns run ios --syncAllFiles",
         "demo.android": "npm i && npm run tsc && cd ../demo && tns run android --syncAllFiles",
-        "clean": "rm -rf node_modules && cd ../demo && rm -rf hooks node_modules platforms && cd ../src && npm run plugin.link"
+        "clean": "rm -rf node_modules && cd ../demo && rm -rf hooks node_modules platforms && cd ../src && npm run plugin.link",
+        "postinstall": "node scripts/require-nativescript-telerik-ui.js"
     },
     "keywords": [
         "NativeScript",
@@ -44,13 +45,13 @@
     "homepage": "https://github.com/NativeScript/nativescript-imagepicker",
     "readmeFilename": "README.md",
     "devDependencies": {
+        "nativescript-telerik-ui": "^3.0.0",
         "tns-core-modules": "^3.1.0",
         "tns-platform-declarations": "^3.0.0",
         "typescript": "~2.3.0",
         "tslint": "~5.4.3"
     },
     "dependencies": {
-        "nativescript-telerik-ui": "^3.0.0",
         "nativescript-permissions": "~1.2.3"
     },
     "bootstrapper": "nativescript-plugin-seed"

--- a/src/scripts/require-nativescript-telerik-ui.js
+++ b/src/scripts/require-nativescript-telerik-ui.js
@@ -1,0 +1,25 @@
+var path = require("path"),
+    fs = require("fs"),
+    projectPackageJsonFilename = path.join(__dirname, "..", "..", "..", "package.json"),
+    projectPackageJson;
+
+// ignore the remainder of the script if for some reason no package.json exists
+try { projectPackageJson = require(projectPackageJsonFilename); } catch (ignore) { return; };
+
+// check if either nativescript-telerik-ui or nativescript-telerik-ui-pro are installed
+var telerikui = projectPackageJson.dependencies["nativescript-telerik-ui"];
+var telerikuipro = projectPackageJson.dependencies["nativescript-telerik-ui-pro"];
+
+// if neither are installed, add nativescript-telerik-ui to the project package.json as a dependency,
+// so the user can always later decide to upgrade to nativescript-telerik-ui-pro.
+if (telerikui === undefined && telerikuipro === undefined) {
+
+  // we want to install the same version this plugin is tested with, so grab it from the devDependencies.
+  var pluginPackageJson = require(path.join(__dirname, "..", "package.json"));
+  var telerikuiversion = pluginPackageJson.devDependencies["nativescript-telerik-ui"];
+
+  projectPackageJson.dependencies["nativescript-telerik-ui"] = telerikuiversion;
+  fs.writeFileSync(projectPackageJsonFilename, JSON.stringify(projectPackageJson, null, 2));
+
+  console.log("The nativescript-imagepicker plugin added the nativescript-telerik-ui@" + telerikuiversion + " dependency to your app's package.json.");
+}

--- a/src/scripts/require-nativescript-telerik-ui.js
+++ b/src/scripts/require-nativescript-telerik-ui.js
@@ -1,5 +1,4 @@
 var path = require("path"),
-    fs = require("fs"),
     projectPackageJsonFilename = path.join(__dirname, "..", "..", "..", "package.json"),
     projectPackageJson;
 
@@ -18,8 +17,8 @@ if (telerikui === undefined && telerikuipro === undefined) {
   var pluginPackageJson = require(path.join(__dirname, "..", "package.json"));
   var telerikuiversion = pluginPackageJson.devDependencies["nativescript-telerik-ui"];
 
-  projectPackageJson.dependencies["nativescript-telerik-ui"] = telerikuiversion;
-  fs.writeFileSync(projectPackageJsonFilename, JSON.stringify(projectPackageJson, null, 2));
-
-  console.log("The nativescript-imagepicker plugin added the nativescript-telerik-ui@" + telerikuiversion + " dependency to your app's package.json.");
+  // give the user a bit of feedback as installing this dependency take a while to complete.
+  console.log("The nativescript-imagepicker plugin requires nativescript-telerik-ui. Please wait while it's being added to your project...");
+  require('child_process').execSync('npm i --save nativescript-telerik-ui@' + telerikuiversion, { cwd: path.join(__dirname, "..", "..")});
+  console.log("nativescript-telerik-ui@" + telerikuiversion + " has been successfully installed and was added to your app's package.json.");
 }


### PR DESCRIPTION
Hi,

I saw #50 and wondered if a little `postinstall` script could fix it. Turns out it does, so please review this PR.

What it does is:
- Move the `nativescript-telerik-ui` dependency to devDependencies (so users won't automatically get the non-pro version as well in case they already have the pro version installed).
- Trigger a `postinstall` script that checks whether or not either `nativescript-telerik-ui` or `nativescript-telerik-ui-pro` is installed.
  - If so: do nothing.
  - If not: add `nativescript-telerik-ui` to the project's `package.json`, with the version listed in the plugin `package.json`'s devDependencies. The reason is this way the user can upgrade to `nativescript-telerik-ui-pro` at a later time if he so chooses, simply by changing the project's `package.json` dependency to `-pro`.