### PR TITLE
Added 'newestFirst' to typings

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -93,6 +93,11 @@ interface Options {
     * Set the text for the albums button in iOS
     */
     albumsText?: string;
+
+    /**
+     * Indicates images should be sorted newest-first (iOS only, default false).
+     */
+    newestFirst?: boolean;
 }
 
 export function create(options?: Options): ImagePicker;


### PR DESCRIPTION
#41 introduced the option to have the plugin show the newest images first on iOS, but there was no update to the TS definition file so I'm currently having a hard time using that cool feature in my TS app.

#81 also adds this but that PR tries to fix multiple things so that may explain why it's not merged yet.