### PR TITLE
Fix aspect ratio issue on iOS & add scaling example to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,26 @@ context
 
 > **NOTE**: To request permissions for Android 6+ (API 23+) we use [nativescript-permissions](https://www.npmjs.com/package/nativescript-permissions).
 
+### Process the selection with scaling images to specified dimensions and returning ImageSource object
+
+```
+context
+    .authorize()
+    .then(function() {
+        return context.present();
+    })
+    .then(function(selection) {
+        selection.forEach((selectedPhoto) => {
+            selectedPhoto.getImage({ maxWidth: 500, maxHeight: 500 }) // maintains aspect ratio
+            .then((imageSource) => {
+                // process the selected image
+            });
+        });
+    }).catch(function (e) {
+        // process error
+    });
+```
+
 ## API
 
 ### Methods

--- a/src/imagepicker.ios.ts
+++ b/src/imagepicker.ios.ts
@@ -356,7 +356,7 @@ class ImagePickerPH extends ImagePicker {
             PHImageManager.defaultManager().requestImageForAssetTargetSizeContentModeOptionsResultHandler(
                 image,
                 size,
-                PHImageContentMode.AspectFill,
+                PHImageContentMode.AspectFit, // Scales the image so that its larger dimension fits the target size
                 resizeMode,
                 (createdImage, data) => {
                     if (createdImage) {


### PR DESCRIPTION
Fix aspect ratio issue on iOS where resized images were filled out instead of maintaining the aspect ratio. Also added example for scaling images to the docs.