### PR TITLE
Enabled network access to allow iCloud images to be retrieved when se…

### DIFF
--- a/src/imagepicker.ios.ts
+++ b/src/imagepicker.ios.ts
@@ -266,6 +266,7 @@ class ImagePickerPH extends ImagePicker {
         this._thumbRequestOptions.resizeMode = PHImageRequestOptionsResizeMode.Exact;
         this._thumbRequestOptions.synchronous = false;
         this._thumbRequestOptions.deliveryMode = PHImageRequestOptionsDeliveryMode.Opportunistic;
+        this._thumbRequestOptions.networkAccessAllowed = true; // needed for retrieving iCloud images
         this._thumbRequestOptions.normalizedCropRect = CGRectMake(0, 0, 1, 1);
 
         this._thumbRequestSize = CGSizeMake(80, 80);


### PR DESCRIPTION
An attempt to fix issue with iCloudImage.

As per comment on https://stackoverflow.com/questions/31037859/phimagemanager-requestimageforasset-returns-nil-sometimes-for-icloud-photos the tricky part is to have networkAccessAllowed enabled in order to correctly download.

I've created a local link, and tested that enabling this option solved the issue in my case.