### PR TITLE
chore: migrate to split list-view package

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Imagepicker plugin supporting both single and multiple selection.
 
 - [Installation](#installation)
 - [Configuration](#configuration)
+- [Migrating from 4.x.x to 5.x.x](#migrating-from-4xx-to-5xx)
 - [Migrating from 3.x.x to 4.x.x](#migrating-from-3xx-to-4xx)
 - [Usage](#usage)
     - [Import the plugin](#import-the-plugin)
@@ -34,10 +35,13 @@ In Command prompt / Terminal navigate to your application root folder and run:
 
 ```
 tns plugin add nativescript-imagepicker
-```
+```tns run 
 
 ## Configuration
 No additional configuration required!
+
+## Migrating from 4.x.x to 5.x.x
+With version **5.x.x** major update to the plugin there is a related dependency which needs to be updated inside your project. The plugin uses internally the `nativescript-ui-listview` plugin (part of the NativeScript Pro UI components). Recently the monolithic [NativeScript Pro UI plugin was split in multiple plugins](https://www.nativescript.org/blog/professional-components-from-nativescript-ui-the-big-breakup), each of them representing a single component. Now, instead of the monolithic package, nativescript-imagepicker uses only the component it needs. To use version 5.x.x of the plugin, you need to update any dependencies to `nativescript-pro-ui` in your project with the single component alternatives as described in the [migration guide](http://docs.telerik.com/devtools/nativescript-ui/migration).
 
 ## Migrating from 3.x.x to 4.x.x
 With the **4.x.x** major update to the plugin there is a related dependency which needs to be updated inside your project. The plugin uses internally the `nativescript-pro-ui` plugin (previously known as `nativescript-telerik-ui`) which has bee updated and made 100% free. This means that if your project is using the deprecated `nativescript-telerik-ui`/`pro` plugins adding the latest version of the `nativescript-imagepicker` plugin will cause your project to throw an build error when working with iOS. This is because the `nativescript-imagepicker` has a dependency to the new `nativescript-pro-ui` plugin and when your project also depends on the old `nativescript-telerik-ui` plugin there is a native frameworks collision.

--- a/src/images.ios.ts
+++ b/src/images.ios.ts
@@ -4,7 +4,7 @@ import platform = require("tns-core-modules/platform");
 import ui_frame = require("tns-core-modules/ui/frame");
 import { Page } from "tns-core-modules/ui/page";
 import { ActionBar, NavigationButton, ActionItems, ActionItem } from "tns-core-modules/ui/action-bar";
-import { RadListView, ListViewGridLayout } from "nativescript-pro-ui/listview";
+import { RadListView, ListViewGridLayout } from "nativescript-ui-listview";
 
 let page;
 let list;

--- a/src/images.xml
+++ b/src/images.xml
@@ -1,5 +1,5 @@
 <Page xmlns="http://www.nativescript.org/tns.xsd" loaded="pageLoaded"
-      xmlns:lv="nativescript-pro-ui/listview">
+      xmlns:lv="nativescript-ui-listview">
 
     <Page.actionBar>
         <ActionBar title="{{ title }}">

--- a/src/package.json
+++ b/src/package.json
@@ -16,7 +16,7 @@
     },
     "scripts": {
         "ngc": "node --max-old-space-size=8192 ./node_modules/.bin/ngc",
-        "build": "npm i && tsc", 
+        "build": "npm i && tsc",
         "prepublishOnly": "npm run build",
         "ci.tslint": "npm i && tslint '**/*.ts' --config '../tslint.json' --exclude '**/node_modules/**'",
         "tsc": "tsc -skipLibCheck",
@@ -52,7 +52,7 @@
         "tslint": "~5.4.3"
     },
     "dependencies": {
-        "nativescript-pro-ui": "^3.1.2",
+        "nativescript-ui-listview": "^3.5.0",
         "nativescript-permissions": "~1.2.3"
     },
     "bootstrapper": "nativescript-plugin-seed"


### PR DESCRIPTION
Since recently the nativescript-pro-ui package was split in single component packages. This commit replaces the monolityhic package with the one for list-view
