### PR TITLE
chore: allow only local files for picking

### DIFF
--- a/demo-angular/package.json
+++ b/demo-angular/package.json
@@ -26,7 +26,6 @@
     "tns-core-modules": "^4.0.0"
   },
   "devDependencies": {
-    "@angular/compiler-cli": "~6.1.0-beta.1",
     "babel-traverse": "6.24.1",
     "babel-types": "6.24.1",
     "babylon": "6.16.1",
@@ -42,8 +41,7 @@
     "tns-platform-declarations": "^3.0.0",
     "tslint": "~5.4.3",
     "typescript": "~2.7.2",
-    "zone.js": "^0.8.4",
-    "@ngtools/webpack": "6.1.0-rc.0"
+    "zone.js": "^0.8.4"
   },
   "scripts": {
     "build.plugin": "cd ../src && npm run build",

--- a/src/imagepicker.android.ts
+++ b/src/imagepicker.android.ts
@@ -26,6 +26,11 @@ class UriHelper {
             // DownloadsProvider
             else if (UriHelper.isDownloadsDocument(uri)) {
                 id = DocumentsContract.getDocumentId(uri);
+                // Since Oreo the downloads id may be a raw string,
+                // containing the file path:
+                if (id.indexOf("raw:") !== -1) {
+                    return id.substring(4, id.length);
+                }
                 contentUri = android.content.ContentUris.withAppendedId(
                     android.net.Uri.parse("content://downloads/public_downloads"), long(id));
 
@@ -197,11 +202,7 @@ export class ImagePicker {
             }
 
             intent.putExtra(android.content.Intent.EXTRA_LOCAL_ONLY, true);
-            intent.putExtra(android.content.Intent.CATEGORY_OPENABLE, true);
-            intent.setData(android.provider.MediaStore.Images.Media.EXTERNAL_CONTENT_URI);
-            intent.setAction(android.content.Intent.ACTION_PICK);
-
-
+            intent.setAction("android.intent.action.OPEN_DOCUMENT");
             let chooser = Intent.createChooser(intent, "Select Picture");
             application.android.foregroundActivity.startActivityForResult(intent, RESULT_CODE_PICKER_IMAGES);
         });

--- a/src/imagepicker.android.ts
+++ b/src/imagepicker.android.ts
@@ -196,7 +196,11 @@ export class ImagePicker {
                 intent.putExtra("android.intent.extra.ALLOW_MULTIPLE", true);
             }
 
-            intent.setAction(Intent.ACTION_GET_CONTENT);
+            intent.putExtra(android.content.Intent.EXTRA_LOCAL_ONLY, true);
+            intent.putExtra(android.content.Intent.CATEGORY_OPENABLE, true);
+            intent.setData(android.provider.MediaStore.Images.Media.EXTERNAL_CONTENT_URI);
+            intent.setAction(android.content.Intent.ACTION_PICK);
+
 
             let chooser = Intent.createChooser(intent, "Select Picture");
             application.android.foregroundActivity.startActivityForResult(intent, RESULT_CODE_PICKER_IMAGES);


### PR DESCRIPTION
## PR Checklist

- [X] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [X] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [X] All existing tests are passing

## What is the current behavior?
Currently user is allowed to pick an image from external storage like SDCard, Google Drive, etc. but when an image is selected, its filename is not correctly resolved by the plugin and the image is not displayed in the demo.

## What is the new behavior?
The user is allowed to pick only images from local storage, so when any image is selected it can be correctly visualised by the application.

Related with #189.
