### PR TITLE
fix(ios): no blurred images in image picker

### DIFF
--- a/src/imagepicker.ios.ts
+++ b/src/imagepicker.ios.ts
@@ -24,7 +24,11 @@ export class ImagePicker extends data_observable.Observable {
 
     // lazy-load latest frame.topmost() if _hostName is not used
     get hostView() {
-        return this._hostView || frame.topmost();
+        return this._hostView;
+    }
+
+    get hostController() {
+        return this.hostView ? this.hostView.viewController : UIApplication.sharedApplication.keyWindow.rootViewController;
     }
 
     constructor(options: Options = {}, hostView: View) {
@@ -68,7 +72,7 @@ export class ImagePicker extends data_observable.Observable {
             this._imagePickerControllerDelegate._resolve = resolve;
             this._imagePickerControllerDelegate._reject = reject;
 
-            (<any>this.hostView).viewController.presentViewControllerAnimatedCompletion(this._imagePickerController, true, null);
+            this.hostController.presentViewControllerAnimatedCompletion(this._imagePickerController, true, null);
         });
     }
 }

--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,6 @@
 {
     "name": "nativescript-imagepicker",
-    "version": "6.0.3",
+    "version": "6.0.4",
     "description": "A plugin for the NativeScript framework implementing multiple image picker",
     "repository": {
         "type": "git",
@@ -10,8 +10,8 @@
     "typings": "index.d.ts",
     "nativescript": {
         "platforms": {
-            "android": "3.0.0",
-            "ios": "3.0.0"
+            "android": "4.0.0",
+            "ios": "4.0.0"
         }
     },
     "scripts": {
@@ -46,9 +46,9 @@
     "homepage": "https://github.com/NativeScript/nativescript-imagepicker",
     "readmeFilename": "README.md",
     "devDependencies": {
-        "tns-core-modules": "^3.1.0",
-        "tns-platform-declarations": "^3.1.0",
-        "typescript": "~2.6.0",
+        "tns-core-modules": "^4.0.0",
+        "tns-platform-declarations": "^4.0.0",
+        "typescript": "~2.7.0",
         "tslint": "~5.4.3"
     },
     "dependencies": {


### PR DESCRIPTION
Fix for displaying blurred images in image picker when the root view of the app is any layout nesting TabView. 
Branch on which there is a reproduced bad behaviour is here:
https://github.com/JakubPawlak/nativescript-imagepicker/tree/blur

<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] All existing tests are passing
- [x] Tests for the changes are included

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
In some specific cases, image picker is showing blurred images.
https://github.com/NativeScript/nativescript-imagepicker/issues/195
## What is the new behavior?
<!-- Describe the changes. -->
No blurred images.

Fixes #195
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:

No breaking changes
[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->
No migration steps.