### PR TITLE
fix: register delegate in global scope on creation, clear it when dismissed

### DIFF
--- a/src/imagepicker.ios.ts
+++ b/src/imagepicker.ios.ts
@@ -80,7 +80,7 @@ export class ImagePicker extends data_observable.Observable {
             const imagePickerControllerDelegate = ImagePickerControllerDelegate.new();
             imagePickerControllerDelegate._resolve = resolve;
             imagePickerControllerDelegate._reject = reject;
-            
+
             this._imagePickerController.delegate = imagePickerControllerDelegate;
 
             this.hostController.presentViewControllerAnimatedCompletion(this._imagePickerController, true, null);
@@ -95,7 +95,7 @@ export class ImagePickerControllerDelegate extends NSObject implements QBImagePi
     qb_imagePickerControllerDidCancel?(imagePickerController: QBImagePickerController): void {
         imagePickerController.dismissViewControllerAnimatedCompletion(true, null);
         this._reject(new Error("Selection canceled."));
-        
+
         this.deRegisterFromGlobal();
     }
 
@@ -136,10 +136,10 @@ export class ImagePickerControllerDelegate extends NSObject implements QBImagePi
     }
 
     public static ObjCProtocols = [QBImagePickerControllerDelegate];
-    
+
     static new(): ImagePickerControllerDelegate {
         const instance = <ImagePickerControllerDelegate>super.new(); // calls new() on the NSObject
-        
+
         instance.registerToGlobal();
 
         return instance;

--- a/src/imagepicker.ios.ts
+++ b/src/imagepicker.ios.ts
@@ -26,8 +26,6 @@ export class ImagePicker extends data_observable.Observable {
         return this._hostView;
     }
 
-
-
     get hostController(): UIViewController {
         let vc = this.hostView ? this.hostView.viewController : UIApplication.sharedApplication.keyWindow.rootViewController;
         while (


### PR DESCRIPTION
addresses #251 
The issue seems to be caused by freeing up the delegate instance on the native side ([stored as weak](https://github.com/questbeat/QBImagePicker/blob/93ba9d54016722e82d46e1cf19750dd285b81a81/QBImagePicker/QBImagePickerController.h#L34)). Storing it in the global scope on the JS side prevents the runtime from collecting it.