### PR TITLE
chore: update permissions version

### DIFF
--- a/src/package.json
+++ b/src/package.json
@@ -52,7 +52,7 @@
         "tslint": "~5.11.0"
     },
     "dependencies": {
-        "nativescript-permissions": "~1.2.3"
+        "nativescript-permissions": "~1.3.0"
     },
     "bootstrapper": "nativescript-plugin-seed"
 }


### PR DESCRIPTION
## What is the current behavior?
This plugin uses 1.2.* version of nativescript-permissions, which is using the legacy support library

## What is the new behavior?
This plugin uses 1.3.* version of nativescript-permissions, which supports both AndroidX and the legacy support library

Related with: https://github.com/NativeScript/nativescript-imagepicker/issues/263

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->
