### PR TITLE
feat(android): add support for mediaType option for android devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ context
 | prompt | iOS | undefined | Display prompt text when selecting assets. |
 | numberOfColumnsInPortrait | iOS | 4 | Set the number of columns in Portrait orientation. |
 | numberOfColumnsInLandscape | iOS | 7 | Set the number of columns in Landscape orientation. |
-| mediaType | iOS | Any | Choose whether to pick Image/Video/Any type of assets. |
+| mediaType | both | Any (iOS), Image (Android) | Choose whether to pick Image/Video/Any type of assets. |
 
 The **hostView** parameter can be set to the view that hosts the image picker. Applicable in iOS only, intended to be used when open picker from a modal page.
 

--- a/src/imagepicker.android.ts
+++ b/src/imagepicker.android.ts
@@ -2,6 +2,8 @@ import * as application from "tns-core-modules/application";
 import * as imageAssetModule from "tns-core-modules/image-asset";
 import * as permissions from "nativescript-permissions";
 
+import { ImagePickerMediaType } from ".";
+
 class UriHelper {
     public static _calculateFileUri(uri: android.net.Uri) {
         let DocumentsContract = (<any>android.provider).DocumentsContract;
@@ -126,6 +128,17 @@ export class ImagePicker {
         return this._options && this._options.mode && this._options.mode.toLowerCase() === 'single' ? 'single' : 'multiple';
     }
 
+    get mediaType(): string {
+        const mediaType = this._options && 'mediaType' in this._options ? this._options.mediaType : ImagePickerMediaType.Image;
+        if (mediaType === ImagePickerMediaType.Image) {
+            return "image/*";
+        } else if (mediaType === ImagePickerMediaType.Video) {
+            return "video/*";
+        } else {
+            return "*/*";
+        }
+    }
+
     authorize(): Promise<void> {
         if ((<any>android).os.Build.VERSION.SDK_INT >= 23) {
             return permissions.requestPermission([(<any>android).Manifest.permission.READ_EXTERNAL_STORAGE]);
@@ -194,7 +207,7 @@ export class ImagePicker {
 
             let Intent = android.content.Intent;
             let intent = new Intent();
-            intent.setType("image/*");
+            intent.setType(this.mediaType);
 
             // TODO: Use (<any>android).content.Intent.EXTRA_ALLOW_MULTIPLE
             if (this.mode === 'multiple') {

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -63,7 +63,7 @@ interface Options {
     numberOfColumnsInLandscape?: number;
 
     /**
-     * Set the media type (image/video/both) to pick in iOS
+     * Set the media type (image/video/any) to pick
      */
     mediaType?: ImagePickerMediaType;
 


### PR DESCRIPTION
@xuhcc created [a PR](https://github.com/NativeScript/nativescript-imagepicker/pull/277):

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] All existing tests are passing
- [ ] Tests for the changes are included

## What is the current behavior?

`mediaType` option only works on iOS.

## What is the new behavior?

`mediaType` option supported on Android too.

Related with #175.