### PR TITLE
fix: not exported type

### DIFF
--- a/src/imagepicker.android.ts
+++ b/src/imagepicker.android.ts
@@ -2,6 +2,9 @@ import * as application from "tns-core-modules/application";
 import * as imageAssetModule from "tns-core-modules/image-asset";
 import * as permissions from "nativescript-permissions";
 
+import { ImagePickerMediaType, Options } from "./imagepicker.common";
+export * from "./imagepicker.common";
+
 class UriHelper {
     public static _calculateFileUri(uri: android.net.Uri) {
         let DocumentsContract = (<any>android.provider).DocumentsContract;
@@ -133,9 +136,9 @@ class UriHelper {
 }
 
 export class ImagePicker {
-    private _options;
+    private _options: Options;
 
-    constructor(options) {
+    constructor(options: Options) {
         this._options = options;
     }
 
@@ -226,6 +229,6 @@ export class ImagePicker {
     }
 }
 
-export function create(options?): ImagePicker {
+export function create(options?: Options): ImagePicker {
     return new ImagePicker(options);
 }

--- a/src/imagepicker.common.ts
+++ b/src/imagepicker.common.ts
@@ -1,0 +1,57 @@
+export enum ImagePickerMediaType {
+    Any = 0,
+    Image = 1,
+    Video = 2
+}
+
+/**
+ * Provide options for the image picker.
+ */
+export interface Options {
+    /**
+     * Set the picker mode. Supported modes: "single" or "multiple" (default).
+     */
+    mode?: string;
+
+    /**
+    * Set the minumum number of selected assets in iOS
+    */
+    minimumNumberOfSelection?: number;
+
+    /**
+     * Set the maximum number of selected assets in iOS
+     */
+    maximumNumberOfSelection?: number;
+
+    /**
+     * Display the number of selected assets in iOS
+     */
+    showsNumberOfSelectedAssets?: boolean;
+
+    /**
+     * Display prompt text when selecting assets in iOS
+     */
+    prompt?: string;
+
+    /**
+     * Set the number of columns in Portrait in iOS
+     */
+    numberOfColumnsInPortrait?: number;
+
+    /**
+     * Set the number of columns in Landscape in iOS
+     */
+    numberOfColumnsInLandscape?: number;
+
+    /**
+     * Set the media type (image/video/any) to pick
+     */
+    mediaType?: ImagePickerMediaType;
+
+    android?: {
+        /**
+         * Provide a reason for permission request to access external storage on api levels above 23.
+         */
+        read_external_storage?: string;
+    };
+}

--- a/src/imagepicker.ios.ts
+++ b/src/imagepicker.ios.ts
@@ -1,8 +1,9 @@
 import * as data_observable from "tns-core-modules/data/observable";
 import * as imageAssetModule from "tns-core-modules/image-asset";
-import { Options, ImagePickerMediaType } from ".";
+import { Options, ImagePickerMediaType } from "./imagepicker.common";
 import { View } from "tns-core-modules/ui/core/view/view";
 import * as utils from "tns-core-modules/utils/utils";
+export * from "./imagepicker.common";
 
 const defaultAssetCollectionSubtypes: NSArray<any> = NSArray.arrayWithArray(<any>[
     PHAssetCollectionSubtype.SmartAlbumRecentlyAdded,


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [X] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [X] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [X] All existing tests are passing
- [ ] Tests for the changes are included

## What is the current behavior?
There is a ImagePickerMediaType enum that seems like it can be added to the [demo app](https://github.com/NativeScript/nativescript-imagepicker/blob/master/demo/app/main-view-model.ts#L71):
```
let context = imagepicker.create({ mode: "single", mediaType: imagepicker.ImagePickerMediaType.Image });
```
However when I run the app, it crashes with` Cannot read property 'Image' of undefined`

## What is the new behavior?
App doesn't crash with the above changes

Related with https://github.com/NativeScript/nativescript-imagepicker/issues/285.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->
