### PR TITLE
fix(android): don't set EXTRA_MIME_TYPES when using 'Any' media type on Android

### DIFF
--- a/src/imagepicker.android.ts
+++ b/src/imagepicker.android.ts
@@ -227,19 +227,13 @@ export class ImagePicker {
             let intent = new Intent();
             intent.setType(this.mediaType);
 
-            let length  = this.mediaType === "*/*" ? 2 : 1;
-            let mimeTypes = Array.create(java.lang.String, length);
-
-            if (this.mediaType === "*/*") {
-                mimeTypes[0] = "image/*";
-                mimeTypes[1] = "video/*";
-            }
-            else {
+            if (this.mediaType !== '*/*') {
+                let mimeTypes = Array.create(java.lang.String, 1);
                 mimeTypes[0] = this.mediaType;
+                // not in platform-declaration typings
+                intent.putExtra((android.content.Intent as any).EXTRA_MIME_TYPES, mimeTypes);
             }
 
-            // not in platform-declaration typings
-            intent.putExtra((android.content.Intent as any).EXTRA_MIME_TYPES, mimeTypes);
             // TODO: Use (<any>android).content.Intent.EXTRA_ALLOW_MULTIPLE
             if (this.mode === 'multiple') {
                 intent.putExtra("android.intent.extra.ALLOW_MULTIPLE", true);


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] All existing tests are passing
- [ ] Tests for the changes are included

## What is the current behavior?

On Android, even when media type is set to `ImagePickerMediaType.Any`, it is not possible to select any file except image or video, everything else is greyed out.

## What is the new behavior?

You can select any file.

Partly reverts changes made in #290 and #291.

