### PR TITLE
feat(android): add option for showing internal/external storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,6 @@ Imagepicker plugin supporting both single and multiple selection.
     - [Request permissions, show the images list and process the selection](#request-permissions-show-the-images-list-and-process-the-selection)
 - [API](#api)
     - [Methods](#methods)
-    - [Properties](#properties)
-    - [Image properties](#image-properties)
 - [Contribute](#contribute)
 - [Get Help](#get-help)
 
@@ -134,6 +132,7 @@ context
 | numberOfColumnsInPortrait | iOS | 4 | Set the number of columns in Portrait orientation. |
 | numberOfColumnsInLandscape | iOS | 7 | Set the number of columns in Landscape orientation. |
 | mediaType | both | Any | Choose whether to pick Image/Video/Any type of assets. |
+| showAdvanced | Android | false | Show internal and removable storage options on Android (**WARNING**: [not supported officially](https://issuetracker.google.com/issues/72053350)). |
 
 The **hostView** parameter can be set to the view that hosts the image picker. Applicable in iOS only, intended to be used when open picker from a modal page.
 

--- a/src/imagepicker.android.ts
+++ b/src/imagepicker.android.ts
@@ -245,6 +245,10 @@ export class ImagePicker {
                 intent.putExtra("android.intent.extra.ALLOW_MULTIPLE", true);
             }
 
+            if (this._options.showAdvanced) {
+                intent.putExtra("android.content.extra.SHOW_ADVANCED", true);
+            }
+
             intent.putExtra(android.content.Intent.EXTRA_LOCAL_ONLY, true);
             intent.setAction("android.intent.action.OPEN_DOCUMENT");
             let chooser = Intent.createChooser(intent, "Select Picture");

--- a/src/imagepicker.common.ts
+++ b/src/imagepicker.common.ts
@@ -48,6 +48,12 @@ export interface Options {
      */
     mediaType?: ImagePickerMediaType;
 
+    /**
+     * Show internal and removable storage options on Android.
+     * Not supported officially, see https://issuetracker.google.com/issues/72053350 |
+     */
+    showAdvanced?: boolean;
+
     android?: {
         /**
          * Provide a reason for permission request to access external storage on api levels above 23.

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -67,12 +67,19 @@ interface Options {
      */
     mediaType?: ImagePickerMediaType;
 
+    /**
+     * Show internal and removable storage options on Android.
+     * Not supported officially, see https://issuetracker.google.com/issues/72053350 |
+     */
+    showAdvanced?: boolean;
+
     android?: {
         /**
          * Provide a reason for permission request to access external storage on api levels above 23.
          */
         read_external_storage?: string;
     };
+
 }
 
 /**


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] All existing tests are passing
- [ ] Tests for the changes are included

## What is the current behavior?

Internal and external storage may not be shown by default in Android file chooser.

## What is the new behavior?

The new `showAdvanced` option forces the file chooser to show these locations. However, under the hood, it uses an undocumented android function, so the warning was added to readme.

I also removed two broken links from TOC.
