### PR TITLE
refactor(android): add mimeTypes property to ImagePicker class

### DIFF
--- a/src/imagepicker.android.ts
+++ b/src/imagepicker.android.ts
@@ -157,6 +157,20 @@ export class ImagePicker {
         }
     }
 
+    get mimeTypes() {
+        let length = this.mediaType === "*/*" ? 2 : 1;
+        let mimeTypes = Array.create(java.lang.String, length);
+
+        if (this.mediaType === "*/*") {
+            mimeTypes[0] = "image/*";
+            mimeTypes[1] = "video/*";
+        }
+        else {
+            mimeTypes[0] = this.mediaType;
+        }
+        return mimeTypes;
+    }
+
     authorize(): Promise<void> {
         if ((<any>android).os.Build.VERSION.SDK_INT >= 23) {
             return permissions.requestPermission([(<any>android).Manifest.permission.READ_EXTERNAL_STORAGE]);
@@ -227,19 +241,9 @@ export class ImagePicker {
             let intent = new Intent();
             intent.setType(this.mediaType);
 
-            let length  = this.mediaType === "*/*" ? 2 : 1;
-            let mimeTypes = Array.create(java.lang.String, length);
-
-            if (this.mediaType === "*/*") {
-                mimeTypes[0] = "image/*";
-                mimeTypes[1] = "video/*";
-            }
-            else {
-                mimeTypes[0] = this.mediaType;
-            }
-
             // not in platform-declaration typings
-            intent.putExtra((android.content.Intent as any).EXTRA_MIME_TYPES, mimeTypes);
+            intent.putExtra((android.content.Intent as any).EXTRA_MIME_TYPES, this.mimeTypes);
+
             // TODO: Use (<any>android).content.Intent.EXTRA_ALLOW_MULTIPLE
             if (this.mode === 'multiple') {
                 intent.putExtra("android.intent.extra.ALLOW_MULTIPLE", true);

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -4,6 +4,9 @@ import { ImageAsset } from "tns-core-modules/image-asset";
 import { View } from "tns-core-modules/ui/core/view/view";
 
 export class ImagePicker {
+
+    constructor(options?: Options);
+
     /**
      * Call this before 'present' to request any additional permissions that may be necessary.
      * In case of failed authorization consider notifying the user for degraded functionality.


### PR DESCRIPTION
Following the discussion in #301

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] All existing tests are passing
- [ ] Tests for the changes are included

## What is the current behavior?

On Android, even when media type is set to `ImagePickerMediaType.Any`, it is not possible to select any file except image or video, everything else is greyed out.

## What is the new behavior?

Behavior remains the same, but the new code structure would allow customization of picker behavior in subclasses, for example:

```typescript
class FilePicker extends ImagePicker {

    get mimeTypes() {
        let mimeTypes = Array.create(java.lang.String, 1);
        mimeTypes[0] = '*/*';
        return mimeTypes;
    }
}
```
