### PR TITLE
fix(android): Fix picking from 'SDCARD' location

### DIFF
--- a/src/imagepicker.android.ts
+++ b/src/imagepicker.android.ts
@@ -22,9 +22,20 @@ class UriHelper {
 
                 if ("primary" === type.toLowerCase()) {
                     return android.os.Environment.getExternalStorageDirectory() + "/" + id;
+                } else {
+                    if (android.os.Build.VERSION.SDK_INT > 23) {
+                        (this.getContentResolver() as any).takePersistableUriPermission(
+                            uri,
+                            android.content.Intent.FLAG_GRANT_READ_URI_PERMISSION | android.content.Intent.FLAG_GRANT_WRITE_URI_PERMISSION,
+                        );
+                        const externalMediaDirs = application.android.context.getExternalMediaDirs();
+                        if (externalMediaDirs.length > 1) {
+                            let filePath = externalMediaDirs[1].getAbsolutePath();
+                            filePath = filePath.substring(0, filePath.indexOf("Android")) + id;
+                            return filePath;
+                        }
+                    }
                 }
-
-                // TODO handle non-primary volumes
             }
             // DownloadsProvider
             else if (UriHelper.isDownloadsDocument(uri)) {


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] All existing tests are passing
- [ ] Tests for the changes are included

## What is the current behavior?

Picking files from SDCARD location doesn't work. Here's an example of the selection result:

```
[{
  "_observers": {},
  "_options": {
    "keepAspectRatio": true,
    "autoScaleFactor": true
  },
  "_android": ""
}]
```

## What is the new behavior?

Now it's working (at least in some cases).
